### PR TITLE
Fix CI failures: add pytest dep, fix shell glob, fix release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,13 +42,17 @@ jobs:
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
         git add -A
-        git diff --quiet && git diff --staged --quiet || git commit -m "Update models ${{ steps.date.outputs.date }}"
-        git push
+        git diff --quiet && git diff --staged --quiet || (git commit -m "Update models ${{ steps.date.outputs.date }}" && git push)
+
+    - name: Create and push tag
+      run: |
+        git tag -f "v${{ steps.date.outputs.date }}"
+        git push -f origin "v${{ steps.date.outputs.date }}"
 
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ steps.date.outputs.date }}
+        tag_name: v${{ steps.date.outputs.date }}
         name: Release ${{ steps.date.outputs.date }}
         body: Automated monthly update for ${{ steps.date.outputs.date }}
       env:

--- a/2.convert.sh
+++ b/2.convert.sh
@@ -10,7 +10,8 @@ output_uvl="./flama-uvl"
 mkdir -p "$output_fama" "$output_uvl"
 
 # Remove previous generated models to avoid possible append problems
-rm -f "$output_fama"/* "$output_uvl"/*
+find "$output_fama" -type f -delete 2>/dev/null || true
+find "$output_uvl" -type f -delete 2>/dev/null || true
 
 success=0
 failed=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4>=4.12,<5
 flamapy==1.1.3
 flamapy-fm==1.1.3
 tabulate>=0.9,<1
+pytest>=7.0,<9


### PR DESCRIPTION
- Add pytest to requirements.txt (was missing, causing CI test step to fail)
- Replace rm glob with find -delete in 2.convert.sh (glob on empty dir fails with set -euo pipefail)
- Fix GitHub Actions workflow: create tag before release, only push when there are actual changes to commit

https://claude.ai/code/session_01VfLwZCPTD4knVE9KjtT8KK